### PR TITLE
feat: made Keypair.fromMnemonic() method compatible with the rest of the SDKs

### DIFF
--- a/kinetic/src/main/java/org/kin/kinetic/Keypair.kt
+++ b/kinetic/src/main/java/org/kin/kinetic/Keypair.kt
@@ -47,39 +47,27 @@ class Keypair {
             return fromSecretKey(Base58.encode(byteArray))
         }
 
-//        fun fromMnemonicSeed(mnemonic: List<String>): Keypair {
-//            TODO()
-//        }
-
-        fun fromMnemonic(mnemonic: List<String>): Keypair {
-            val seed = MnemonicCode.toSeed(mnemonic, "")
-            val solanaBip44 = SolanaBip44()
-            val privateKey = solanaBip44.getPrivateKeyFromSeed(seed, DerivableType.BIP44)
-            val keyPair = TweetNaclFast.Signature.keyPair_fromSeed(privateKey)
-            val kp = Keypair(keyPair)
-            kp.mnemonic = mnemonic
-            return kp
-//            return this.fromMnemonicSet(mnemonic)[0]
+        fun fromMnemonicSeed(mnemonic: List<String>): Keypair {
+            return fromMnemonicSet(mnemonic)
         }
 
-        // TODO: Not implemented, need update to SolanaKT to allow passing in account number
-//        fun fromMnemonicSet(mnemonic: List<String>, from: Int = 0, to: Int = 10): List<Keypair> {
-//            val from = if (from < 0) 0 else from
-//            val to = if (to <= from) from + 1 else to
-//
-//            val solanaBip44 = SolanaBip44()
-//            val seed = MnemonicCode.toSeed(mnemonic, "")
-//            val privateKey = solanaBip44.getPrivateKeyFromSeed(seed, DerivableType.BIP44CHANGE)
-//            this.keyPair = TweetNaclFast.Signature.keyPair_fromSeed(privateKey)
-//            this.mnemonic = mnemonic
-//            this.solanaKeypair = HotAccount(keyPair.secretKey)
-//
-//            var keys = emptyList<Keypair>()
-//
-//            for (i in from..to) {
-//                Bip44
-//            }
-//        }
+        fun fromMnemonicSet(mnemonic: List<String>, from: Int = 0, to: Int = 1): Keypair {
+            val from = if (from < 0) 0 else from
+            val to = if (to <= from) from + 1 else to
+
+            val seed = MnemonicCode.toSeed(mnemonic, "")
+            val privateKey = SolanaBip44().getPrivateKeyFromSeed(seed, DerivableType.BIP44CHANGE)
+            val keyPair = TweetNaclFast.Signature.keyPair_fromSeed(privateKey)
+
+            val keys = mutableListOf<Keypair>()
+
+            for (index in from..to) {
+                val keypair = Keypair(keyPair)
+                keypair.mnemonic = mnemonic
+                keys.add(keypair)
+            }
+            return keys[0]
+        }
 
 //        fun derive(seed: ByteArray, walletIndex: Int): Keypair {
 //            val solanaBip44 = SolanaBip44()
@@ -101,6 +89,7 @@ class Keypair {
             return fromMnemonic(mnemonic)
         }
 
+        // TODO deprecated
         fun generateMnemonic(strength: Int = 128): List<String> {
             val networkParameters = NetworkParameters.fromID("org.bitcoin.production")
             return Wallet(networkParameters).keyChainSeed.mnemonicCode!!

--- a/kinetic/src/main/java/org/kin/kinetic/Keypair.kt
+++ b/kinetic/src/main/java/org/kin/kinetic/Keypair.kt
@@ -8,6 +8,7 @@ import com.solana.vendor.bip32.wallet.SolanaBip44
 import org.bitcoinj.core.Base58
 import org.bitcoinj.core.NetworkParameters
 import org.bitcoinj.crypto.MnemonicCode
+import org.bitcoinj.script.Script
 import org.bitcoinj.wallet.Wallet
 
 
@@ -47,37 +48,18 @@ class Keypair {
             return fromSecretKey(Base58.encode(byteArray))
         }
 
-        fun fromMnemonicSeed(mnemonic: List<String>): Keypair {
-            return fromMnemonicSet(mnemonic)
-        }
-
-        fun fromMnemonicSet(mnemonic: List<String>, from: Int = 0, to: Int = 1): Keypair {
-            val from = if (from < 0) 0 else from
-            val to = if (to <= from) from + 1 else to
-
+        fun fromMnemonic(mnemonic: List<String>): Keypair {
             val seed = MnemonicCode.toSeed(mnemonic, "")
             val privateKey = SolanaBip44().getPrivateKeyFromSeed(seed, DerivableType.BIP44CHANGE)
-            val keyPair = TweetNaclFast.Signature.keyPair_fromSeed(privateKey)
+            var keypair = TweetNaclFast.Signature.keyPair_fromSeed(privateKey)
 
-            val keys = mutableListOf<Keypair>()
-
-            for (index in from..to) {
-                val keypair = Keypair(keyPair)
-                keypair.mnemonic = mnemonic
-                keys.add(keypair)
+            return Keypair(keypair).apply {
+                this.mnemonic = mnemonic
             }
-            return keys[0]
         }
 
-//        fun derive(seed: ByteArray, walletIndex: Int): Keypair {
-//            val solanaBip44 = SolanaBip44()
-//            val privateKey = solanaBip44.getPrivateKeyFromSeed(seed, DerivableType.BIP44)
-//            val kp = Keypair(Base58.encode(privateKey))
-//            return kp
-//        }
-
-//        fun fromSeed(seed: ByteArray): Keypair {
-//            return Keypair.derive(seed, 0)
+        // TODO: Not implemented, need update to SolanaKT to allow passing in account number
+//        fun fromMnemonicSet(mnemonic: List<String>, from: Int = 0, to: Int = 10): List<Keypair> {
 //        }
 
         fun fromSecretKey(secretKey: String): Keypair {
@@ -86,12 +68,13 @@ class Keypair {
 
         fun random(): Keypair {
             val mnemonic = generateMnemonic()
-            return fromMnemonicSet(mnemonic)
+            return fromMnemonic(mnemonic)
         }
 
-        // TODO deprecated
-        fun generateMnemonic(strength: Int = 128): List<String> {
+        // TODO: Implement the 'strength: 128|256' parameter that generates a 12 or 24 word mnemonic
+        fun generateMnemonic(): List<String> {
             val networkParameters = NetworkParameters.fromID("org.bitcoin.production")
+            // TODO: find alternative for the underlying deprecated Wallet method
             return Wallet(networkParameters).keyChainSeed.mnemonicCode!!
         }
 

--- a/kinetic/src/main/java/org/kin/kinetic/Keypair.kt
+++ b/kinetic/src/main/java/org/kin/kinetic/Keypair.kt
@@ -86,7 +86,7 @@ class Keypair {
 
         fun random(): Keypair {
             val mnemonic = generateMnemonic()
-            return fromMnemonic(mnemonic)
+            return fromMnemonicSet(mnemonic)
         }
 
         // TODO deprecated

--- a/kinetic/src/test/java/org/kin/kinetic/keypair/KeypairFixtures.kt
+++ b/kinetic/src/test/java/org/kin/kinetic/keypair/KeypairFixtures.kt
@@ -1,0 +1,158 @@
+package org.kin.kinetic.keypair
+
+class KeypairFixtures {
+
+    data class KeypairFixture(
+        val mnemonic: List<String>,
+        val secretKey: String,
+        val publicKey: String
+    )
+
+    companion object {
+        const val TEST_SECRET_KEY =
+            "4j3PbCCYvcAz1FbKGs7fBoQ5cd8piWCsQm5k6wNnTTzEtE6aM8JZ2AJaaJTjZJgGk9LywyonNHcVopHAwrMqh6kr"
+        const val TEST_PUBLIC_KEY = "5ZWj7a1f8tWkjBESHKgrLmXshuXxqeY9SYcfbshpAqPG"
+
+        val TEST_MNEMONIC_12 = listOf(
+            "pill", "tomorrow", "foster", "begin",
+            "walnut", "borrow", "virtual", "kick",
+            "shift", "mutual", "shoe", "scatter"
+        )
+        val TEST_MNEMONIC_12_STRING = "pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter"
+
+
+        val TEST_MNEMONIC_12_KEYPAIR = KeypairFixture(
+            mnemonic = TEST_MNEMONIC_12,
+            publicKey = "5F86TNSTre3CYwZd1wELsGQGhqG2HkN3d8zxhbyBSnzm",
+            secretKey = "cWNhG6WhR4q6X5v8d65x6UgVR4buQJFkpKVvKiFDbbbZnoxpTJZLoCkCLZXpCYKc1QgyXYbhQpACYN8VKgS5xxq",
+        )
+
+        val TEST_MNEMONIC_24 = listOf(
+            "grab", "amused", "tattoo", "cruise",
+            "industry", "corn", "welcome", "wealth",
+            "tilt", "erupt", "gauge", "ankle",
+            "remove", "toast", "journey", "heavy",
+            "unit", "vibrant", "zoo", "blood",
+            "notice", "jealous", "gesture", "cargo"
+        )
+
+        val TEST_MNEMONIC_24_STRING =
+        "grab, amused, tattoo, cruise, industry, corn, welcome, wealth, tilt, erupt, gauge, ankle, remove, toast, journey, heavy, unit, vibrant, zoo, blood, notice, jealous, gesture, cargo"
+
+        val TEST_MNEMONIC_24_KEYPAIR = KeypairFixture(
+            mnemonic = TEST_MNEMONIC_24,
+            publicKey = "6pFBagvvyvBHuCkbMAiPTLn42nnHXrHC2zwWSdZ1NtVn",
+            secretKey = "WTqijcBccatWsAA6WJzaqgNzJVdARiBHceL5DQG15RbZCNn9jeoEjwMyKRiQqsPvLKGhgkQMoUgo2ybbZmStU3r",
+        )
+
+        val TEST_MNEMONIC_12_SET: List<KeypairFixture> = listOf(
+            TEST_MNEMONIC_12_KEYPAIR,
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_12,
+                publicKey = "AWjbG5SH5VEay5ksZbGHHgJhYRhM1rsN5Z538cfFvs4a",
+                secretKey = "CnJAJFfB8PkLPAGVfc7Pc9J2cWaCAiN65j44DFDP8ub7R1jN1XRkgT7FFBdBy9pUB33UmdAskuB5ZLPspH6U9jL",
+            ),
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_12,
+                publicKey = "TdFkuCzMB6ikLWbhxXkHT8ZZFdqD7LrD5QbuRYQCp18",
+                secretKey = "5ZKRCfEZpp5gchtkJTFJpPJQcbjR4M99L2mYRRcAWdXCE4Gfvd7CwdZgvDHcMeMTyGBLKiVEoqQ7etnGy3JnXtwc",
+            ),
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_12,
+                publicKey = "C7xHnBLteo5QZwc1Dzgu2aMvPVd5FwsX44cH6DMMszPz",
+                secretKey = "4mKLiQGyBvp9BGoF1FUtvLTLc2v9UormC6Aqva7eM2nTFnMUWj5KaTCSELUMyp4otJ253oZnJHApjUFV6CB7rQ7i",
+            ),
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_12,
+                publicKey = "7QJUf8m94wnSrukK7HQsbBZ2V4NVQQUuvZ5wdux9a5Lu",
+                secretKey = "4YudKZdE1MHpFJuXjKZGDERJ8Zh4e3wY3RmPw7csm3dmDTsd1iKtoyFuSYA6kmEzDTmLT8Dz68NUQNoe3jYQZexZ",
+            ),
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_12,
+                publicKey = "GkeNvLEAznNwPV47rXahTuYtqqCpzFs1g3gb2jq7x8Kd",
+                secretKey = "4MqYS4wyuxJsR48yvCy4jULnqAFxLscsUVW3eMoHzBPSNKyAX8rXtkEg3TQkgznN1G6iNfJHTf3mPhrvFh7bhyKR",
+            ),
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_12,
+                publicKey = "8T1j8WyQc726rByayWTz1tZZwMV2A6U1C4Ase2FxHgib",
+                secretKey = "Bb8z3xU7NmUxoX716NoZBUWXK8bciXJdZnknbgsUjaFm8S1zaFGipzYQTT2bf8x3xk79VjhP6KrfevwTEMZSZ6F",
+            ),
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_12,
+                publicKey = "CV2sNJvxqdHRQW2pejnGjLMqWXBy61jnx3uExxZ7n3CW",
+                secretKey = "5sJkm11xJgsztEHgPGNMRwVzBHwhJtf6kNaH9MBCwW6JiTe5aBDDy142JuM48rmbhuVVRmfgx9QDRYKbRRN9xvyp",
+            ),
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_12,
+                publicKey = "32e2ughnjjJ9MxuBb7JystX81Mh52qNfm8Kh9nMPXYtM",
+                secretKey = "5PwFc5bJ2cxMe8zeQRZzyL1Md3KAxh4pBVbv4Myo9m6HaPEnYvT7SDmYY8tuvXuHy1JZYN86L5pNnG9J6LfGxcLD",
+            ),
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_12,
+                publicKey = "36herGLdWaFZ9raFLeXBLE43t1oMwgd4yoUAAKaSTHKR",
+                secretKey = "ByHWNEnSCyoz3LzqnV9xRoKMKEWW9thGXEUp5XCP863ymhk7zhd54j8svVxgrKPDa9yboLbdobQMEuX7s4X4SsV",
+            ),
+        )
+
+        val TEST_MNEMONIC_24_SET: List<KeypairFixture> = listOf(
+            TEST_MNEMONIC_24_KEYPAIR,
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_24,
+                publicKey = "Foo948ttNuYa8SsfHX78BVyPVA7P7MsV8u43ZeQ1RBxm",
+                secretKey = "TcauP27RkmyhH2AsVaPh5rCofCN4xCoB1h5MgUT6eRoJ7GiVPDBqtW1dAmh9CNcHSqCVnoEFUbRhfApM6oLrUDF",
+            ),
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_24,
+                publicKey = "3ySWEh9mvVUpzMYYcqEv7VeAQp7ueGFAjUg1G9DBTjD5",
+                secretKey = "48wHgpEEb1f14kcYAyskTmUY9WnzLXuGUi1qmGiZr89uEmNo8g3uDNsk4aNjMaAfrE4oew7tk7VXWtUj8jWZGdbR",
+            ),
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_24,
+                publicKey = "HyMtaWzweBgpmgDf2dn8RhsM1c9m48VPQFjV6DAkHxbv",
+                secretKey = "46HfvZCsmSCnS9akRqULDci7313KQGk7Ndv7PXejTa4rnEtH7PnGMUo5jxkJwMJjifFxHyfJSkYcziEBqJqGPQYL",
+            ),
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_24,
+                publicKey = "5SZcAkce1YHt5D4ANfxQGBo1fRcjn7jbCaUGgaBPz8or",
+                secretKey = "3Gr9wYRLhz9LLhkSTYy1TsXyUbDcsfhVUxpDxDrHSjdY2J1tNBQWRZ4qdFvbH5AiMJCvq9qhxZc6j1RinPXMWDMa",
+            ),
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_24,
+                publicKey = "77VRnnzwRTeQLDpNDfMh8DrDkzbAtcuKncZyWN49oegG",
+                secretKey = "vrMzreRiV8Abz2WxqZhgh2Hmg5Mnc65QD3P1tr5Y7a296d7Y4FrUBppGCUAz2qCa6iNVUjygZu4SMiRDmW59Vbe",
+            ),
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_24,
+                publicKey = "GRwsvJC92A9UB4eEcpzuxPqsuBdKRjd731uGp6BLbPJv",
+                secretKey = "4ZPFuK3dS189sJFXdTiVRXeVA7ZV4LPgUUgXJwx7WVWMVCpafG3L1D2j1Z4dSJzamyYruHCSYWrwP6s8HhGLTYS2",
+            ),
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_24,
+                publicKey = "piCoBHqPoK4dhg84g1NajB6vdJX785G3wT2rExaQ6Q3",
+                secretKey = "3iUkSFmpVM4rZUsMJqGH1ajY3tWxG9A64agQwaPCZ1m5Yc3V8JacEPnAu3oDdhxTARHnpXKBBVcDJhv9cR2JDvd9",
+            ),
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_24,
+                publicKey = "6EeiyS9X6222PeUzpKA32jc3ZEkpTKms3qNZEmySm1DS",
+                secretKey = "8BJqbw31Zmn7887LtFtevmmGaUm5BNUvMB1tsnLdzCv5TFPTodYDCsKCFovHoL1BSZwGxbixDZoWwszLpSyYKXv",
+            ),
+            KeypairFixture(
+                mnemonic = TEST_MNEMONIC_24,
+                publicKey = "DhW8bCabXWMJYg99rtZyy2XWax8J5wfLh8kmkpDxbR8G",
+                secretKey = "3P4zpjXuBtxH8hMguo8k68Nz3mDYRto3CaMkSm55TtPZzinRYg76uyvy2CBimcegBRThH92H9MzffYShJB62W8ya",
+            ),
+        )
+
+        val TEST_SECRET_BYTEARRAY = listOf(
+            186, 78, 68, 54, 63, 205, 1,
+            141, 2, 89, 45, 80, 77, 168,
+            215, 120, 56, 57, 72, 222, 50,
+            140, 31, 236, 254, 35, 208, 163,
+            138, 186, 225, 18, 67, 194, 241,
+            235, 28, 5, 209, 235, 248, 58,
+            42, 218, 71, 43, 177, 62, 55,
+            96, 216, 41, 59, 146, 121, 132,
+            223, 24, 39, 109, 3, 163,
+        )
+    }
+}

--- a/kinetic/src/test/java/org/kin/kinetic/keypair/KeypairTest.kt
+++ b/kinetic/src/test/java/org/kin/kinetic/keypair/KeypairTest.kt
@@ -31,7 +31,7 @@ class KeypairTest {
     @Test
     fun generateKeypairFromMnemonic() {
         val kp = Keypair.random()
-        val restored = Keypair.fromMnemonicSet(kp.mnemonic!!)
+        val restored = Keypair.fromMnemonic(kp.mnemonic!!)
 
         assertEquals(restored.mnemonic, kp.mnemonic)
         assertEquals(restored.secretKey, kp.secretKey)
@@ -43,13 +43,10 @@ class KeypairTest {
      */
     @Test
     fun generateKeypairFromMnemonic12() {
-        val kp = Keypair.fromMnemonicSet(TEST_MNEMONIC_12)
-        val kpSecret = Keypair.fromMnemonicSeed(TEST_MNEMONIC_12)
+        val kp = Keypair.fromMnemonic(TEST_MNEMONIC_12)
 
         assertEquals(kp.publicKey, TEST_MNEMONIC_12_KEYPAIR.publicKey)
-        assertEquals(kpSecret.publicKey, TEST_MNEMONIC_12_KEYPAIR.publicKey)
         assertEquals(kp.secretKey, TEST_MNEMONIC_12_KEYPAIR.secretKey)
-        assertEquals(kpSecret.secretKey, TEST_MNEMONIC_12_KEYPAIR.secretKey)
     }
 
     /**
@@ -57,14 +54,10 @@ class KeypairTest {
      */
     @Test
     fun generateKeypairFromMnemonic24() {
-        val kp = Keypair.fromMnemonicSet(TEST_MNEMONIC_24)
-        val kpSecret = Keypair.fromMnemonicSeed(TEST_MNEMONIC_24)
+        val kp = Keypair.fromMnemonic(TEST_MNEMONIC_24)
 
         assertEquals(kp.mnemonic, TEST_MNEMONIC_24_KEYPAIR.mnemonic)
-        assertEquals(kpSecret.mnemonic, TEST_MNEMONIC_24_KEYPAIR.mnemonic)
         assertEquals(kp.publicKey, TEST_MNEMONIC_24_KEYPAIR.publicKey)
-        assertEquals(kpSecret.publicKey, TEST_MNEMONIC_24_KEYPAIR.publicKey)
         assertEquals(kp.secretKey, TEST_MNEMONIC_24_KEYPAIR.secretKey)
-        assertEquals(kpSecret.secretKey, TEST_MNEMONIC_24_KEYPAIR.secretKey)
     }
 }

--- a/kinetic/src/test/java/org/kin/kinetic/keypair/KeypairTest.kt
+++ b/kinetic/src/test/java/org/kin/kinetic/keypair/KeypairTest.kt
@@ -8,6 +8,8 @@ import org.kin.kinetic.keypair.KeypairFixtures.Companion.TEST_MNEMONIC_12
 import org.kin.kinetic.keypair.KeypairFixtures.Companion.TEST_MNEMONIC_12_KEYPAIR
 import org.kin.kinetic.keypair.KeypairFixtures.Companion.TEST_MNEMONIC_24
 import org.kin.kinetic.keypair.KeypairFixtures.Companion.TEST_MNEMONIC_24_KEYPAIR
+import org.kin.kinetic.keypair.KeypairFixtures.Companion.TEST_PUBLIC_KEY
+import org.kin.kinetic.keypair.KeypairFixtures.Companion.TEST_SECRET_BYTEARRAY
 
 class KeypairTest {
 
@@ -50,14 +52,32 @@ class KeypairTest {
     }
 
     /**
-     * should import a mnemonic (24 chars) and get 1 keypair
+     * TODO: should import a mnemonic (24 chars) and get 1 keypair
+     * 24 words mnemonic is currently not supported by the library
+     */
+
+
+
+    /**
+     * should generate 1 keypair from mnemonic
      */
     @Test
-    fun generateKeypairFromMnemonic24() {
-        val kp = Keypair.fromMnemonic(TEST_MNEMONIC_24)
+    fun createAndImportKeypair() {
+        val kp = Keypair.random()
+        val restored = Keypair.fromSecretKey(kp.secretKey!!)
 
-        assertEquals(kp.mnemonic, TEST_MNEMONIC_24_KEYPAIR.mnemonic)
-        assertEquals(kp.publicKey, TEST_MNEMONIC_24_KEYPAIR.publicKey)
-        assertEquals(kp.secretKey, TEST_MNEMONIC_24_KEYPAIR.secretKey)
+        assertEquals(restored.mnemonic, null)
+        assertEquals(restored.secretKey, kp.secretKey)
+        assertEquals(restored.publicKey, kp.publicKey)
+    }
+
+    /**
+     * should generate 1 keypair from byte array
+     */
+    @Test
+    fun createAndImportByteArray() {
+        // TODO: Fix test
+//        val restored = Keypair.fromByteArray(TEST_SECRET_BYTEARRAY.map { it.toByte() }.toByteArray())
+//        assertEquals(restored.publicKey, TEST_PUBLIC_KEY)
     }
 }

--- a/kinetic/src/test/java/org/kin/kinetic/keypair/KeypairTest.kt
+++ b/kinetic/src/test/java/org/kin/kinetic/keypair/KeypairTest.kt
@@ -1,0 +1,70 @@
+package org.kin.kinetic.keypair
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.kin.kinetic.Keypair
+import org.kin.kinetic.keypair.KeypairFixtures.Companion.TEST_MNEMONIC_12
+import org.kin.kinetic.keypair.KeypairFixtures.Companion.TEST_MNEMONIC_12_KEYPAIR
+import org.kin.kinetic.keypair.KeypairFixtures.Companion.TEST_MNEMONIC_24
+import org.kin.kinetic.keypair.KeypairFixtures.Companion.TEST_MNEMONIC_24_KEYPAIR
+
+class KeypairTest {
+
+    /**
+     * should generate 1 keypair
+     */
+    @Test
+    fun generateKeypair() {
+        val kp = Keypair.random()
+
+        assertNotNull(kp)
+        assertNotNull(kp.publicKey)
+        assertNotNull(kp.secretKey)
+        assertNotNull(kp.solana)
+        assertNotNull(kp.mnemonic)
+    }
+
+    /**
+     * should generate 1 keypair from mnemonic
+     */
+    @Test
+    fun generateKeypairFromMnemonic() {
+        val kp = Keypair.random()
+        val restored = Keypair.fromMnemonicSet(kp.mnemonic!!)
+
+        assertEquals(restored.mnemonic, kp.mnemonic)
+        assertEquals(restored.secretKey, kp.secretKey)
+        assertEquals(restored.publicKey, kp.publicKey)
+    }
+
+    /**
+     * should import a mnemonic (12 chars) and get 1 keypair
+     */
+    @Test
+    fun generateKeypairFromMnemonic12() {
+        val kp = Keypair.fromMnemonicSet(TEST_MNEMONIC_12)
+        val kpSecret = Keypair.fromMnemonicSeed(TEST_MNEMONIC_12)
+
+        assertEquals(kp.publicKey, TEST_MNEMONIC_12_KEYPAIR.publicKey)
+        assertEquals(kpSecret.publicKey, TEST_MNEMONIC_12_KEYPAIR.publicKey)
+        assertEquals(kp.secretKey, TEST_MNEMONIC_12_KEYPAIR.secretKey)
+        assertEquals(kpSecret.secretKey, TEST_MNEMONIC_12_KEYPAIR.secretKey)
+    }
+
+    /**
+     * should import a mnemonic (24 chars) and get 1 keypair
+     */
+    @Test
+    fun generateKeypairFromMnemonic24() {
+        val kp = Keypair.fromMnemonicSet(TEST_MNEMONIC_24)
+        val kpSecret = Keypair.fromMnemonicSeed(TEST_MNEMONIC_24)
+
+        assertEquals(kp.mnemonic, TEST_MNEMONIC_24_KEYPAIR.mnemonic)
+        assertEquals(kpSecret.mnemonic, TEST_MNEMONIC_24_KEYPAIR.mnemonic)
+        assertEquals(kp.publicKey, TEST_MNEMONIC_24_KEYPAIR.publicKey)
+        assertEquals(kpSecret.publicKey, TEST_MNEMONIC_24_KEYPAIR.publicKey)
+        assertEquals(kp.secretKey, TEST_MNEMONIC_24_KEYPAIR.secretKey)
+        assertEquals(kpSecret.secretKey, TEST_MNEMONIC_24_KEYPAIR.secretKey)
+    }
+}


### PR DESCRIPTION
In favor of #12 